### PR TITLE
Zip unzipped dSYM files

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -12,5 +12,21 @@ if [ -z "$dsym_path" ]; then
 	exit 1
 fi
 
+
+zip_dsym_path=""
+zip_ext=".zip"
+
+if [[ "${dsym_path}" == *${zip_ext} ]] ; then
+
+	zip_dsym_path="${dsym_path}"
+
+else
+	printf "\e[34mZipping dSYM...\e[0m\n"
+
+	zip_dsym_path="${dsym_path}${zip_ext}"
+
+	zip -r "${zip_dsym_path}" "${dsym_path}"
+fi
+
 printf "\e[34mUploading dSYM to Xamarin.Insights\e[0m\n"
-curl -w "Upload returned: %{http_code}\\n" -sfF "dsym=@${dsym_path};type=application/zip" "https://xaapi.xamarin.com/api/dsym?apikey=${xamarin_insights_api_key}" -o /dev/null
+curl -w "Upload returned: %{http_code}\\n" -sfF "dsym=@${zip_dsym_path};type=application/zip" "https://xaapi.xamarin.com/api/dsym?apikey=${xamarin_insights_api_key}" -o /dev/null

--- a/step.yml
+++ b/step.yml
@@ -1,7 +1,7 @@
 title: "Xamarin.Insights"
 summary: Upload your dSym to Xamarin.Insights
 description: |-
-  Upload your dSym to Xamarin.Insights
+  Upload your dSYM to Xamarin.Insights
 website: https://github.com/bitrise-steplib/steps-xamarin-insights
 source_code_url: https://github.com/bitrise-steplib/steps-xamarin-insights
 support_url: https://github.com/bitrise-steplib/steps-xamarin-insights/issues
@@ -23,8 +23,8 @@ inputs:
       is_expand: true
   - dsym_path: $BITRISE_DSYM_PATH
     opts:
-      title: Path to your zipped dSYM file
+      title: Path to your dSYM file
       description: |
-        Path to your zipped dSYM file
+        Path to your dSYM file
       is_required: true
       is_expand: true


### PR DESCRIPTION
- Added small change to handle both zipped and unzipped dSYM files.
- Xamarin build tools do not zip the dSYM file, so an additional step
  is required to zip the dSYM before this step can be used.
